### PR TITLE
ignore statuscake.egg-info directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.pyo
 *.egg
+*.egg-info
 .coverage
 pid.egg-info/
 build/


### PR DESCRIPTION
This ignores the `statuscake.egg-info` directory [created by setuptools](https://svn.python.org/projects/sandbox/trunk/setuptools/doc/formats.txt).