### PR TITLE
Add EnableSSLAlert field

### DIFF
--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -73,7 +73,8 @@ class StatusCake(object):
         'TriggerRate': (int, range(0, 61), None),
         'TestTags': (six.string_types, None, to_comma_list),
         'FinalEndpoint': (six.string_types, None, None),
-        'PostRaw': (six.string_types, None, None)
+        'PostRaw': (six.string_types, None, None),
+        'EnableSSLAlert': (int, (0, 1), None)
     }
 
     def __init__(self, api_key, api_user, timeout=10):


### PR DESCRIPTION
EnableSSLAlert (0 = disabled, by default) triggers the "Validate SSL" parameter for a test.

The documentation for the API still lists this parameter as EnableSSLWarning, but after reaching out to Statuscake support I was told to use EnableSSLAlert.

Documentation as of the time of writing still lists EnableSSLWarning here https://www.statuscake.com/api/Tests/Updating%20Inserting%20and%20Deleting%20Tests.md instead of EnableSSLAlert.