### PR TITLE
Various Fixes

### DIFF
--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -244,9 +244,9 @@ class StatusCake(object):
             raise StatusCakeError("data argument must be a dict")
         if 'TestID' not in data:
             raise StatusCakeFieldMissingError("TestID missing")
+        # if CheckRate not passed it will be reset to the account plan default (either 30 or 300)
         if 'CheckRate' not in data:
-            # Use default
-            data['CheckRate'] = 300
+            raise StatusCakeFieldMissingError("CheckRate missing")
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()
 

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -13,6 +13,7 @@ def to_comma_list(value):
         value = ','.join(value)
     return value
 
+
 def to_int(value):
     if isinstance(value, bool):
         value = int(value)

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -13,6 +13,11 @@ def to_comma_list(value):
         value = ','.join(value)
     return value
 
+def to_int(value):
+    if isinstance(value, bool):
+        value = int(value)
+    return value
+
 
 class StatusCake(object):
     URL_LOCATIONS = "https://app.statuscake.com/API/Locations/json"
@@ -52,7 +57,7 @@ class StatusCake(object):
 
     TESTS_FIELDS = {
         'TestID': (int, None, None),
-        'Paused': (int, (0, 1), None),
+        'Paused': (int, (0, 1), to_int),
         'WebsiteName': (six.string_types, None, None),
         'WebsiteURL': (six.string_types, None, None),
         'Port': (int, None, None),
@@ -71,7 +76,7 @@ class StatusCake(object):
         'FindString': (six.string_types, None, None),
         'DoNotFind': (int, (0, 1), None),
         'TestType': (six.string_types, ("HTTP", "TCP", "PING", "PUSH"), None),
-        'ContactGroup': (six.string_types, None, None),
+        'ContactGroup': (six.string_types, None, to_comma_list),
         'RealBrowser': (int, (0, 1), None),
         'TriggerRate': (int, range(0, 61), None),
         'TestTags': (six.string_types, None, to_comma_list),
@@ -231,10 +236,6 @@ class StatusCake(object):
         if 'CheckRate' not in data:
             # Use default
             data['CheckRate'] = 300
-        # Convert list to CSV string of ints
-        if 'ContactGroup' in data:
-            if isinstance(data['ContactGroup'], list):
-                data['ContactGroup'] = ','.join(map(str, data['ContactGroup']))
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()
 
@@ -246,10 +247,6 @@ class StatusCake(object):
         if 'CheckRate' not in data:
             # Use default
             data['CheckRate'] = 300
-        # Convert list to CSV string of ints
-        if 'ContactGroup' in data:
-            if isinstance(data['ContactGroup'], list):
-                data['ContactGroup'] = ','.join(map(str, data['ContactGroup']))
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()
 

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -71,7 +71,7 @@ class StatusCake(object):
         'FindString': (six.string_types, None, None),
         'DoNotFind': (int, (0, 1), None),
         'TestType': (six.string_types, ("HTTP", "TCP", "PING"), None),
-        'ContactGroup': (int, None, None),
+        'ContactGroup': (six.string_types, None, None),
         'RealBrowser': (int, (0, 1), None),
         'TriggerRate': (int, range(0, 61), None),
         'TestTags': (six.string_types, None, to_comma_list),

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -234,7 +234,7 @@ class StatusCake(object):
         if 'TestType' not in data:
             raise StatusCakeFieldMissingError("TestType missing")
         if 'CheckRate' not in data:
-            # Use default
+            # Use free plan default
             data['CheckRate'] = 300
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -231,6 +231,10 @@ class StatusCake(object):
         if 'CheckRate' not in data:
             # Use default
             data['CheckRate'] = 300
+        # Convert list to CSV string of ints
+        if 'ContactGroup' in data:
+            if isinstance(data['ContactGroup'], list):
+                data['ContactGroup'] = ','.join(map(str, data['ContactGroup']))
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()
 
@@ -239,6 +243,10 @@ class StatusCake(object):
             raise StatusCakeError("data argument must be a dict")
         if 'TestID' not in data:
             raise StatusCakeFieldMissingError("TestID missing")
+        # Convert list to CSV string of ints
+        if 'ContactGroup' in data:
+            if isinstance(data['ContactGroup'], list):
+                data['ContactGroup'] = ','.join(map(str, data['ContactGroup']))
         self._check_fields(data, self.TESTS_FIELDS)
         return self._request('put', self.URL_UPDATE_TEST, data=data, **kwargs).json()
 

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -70,7 +70,7 @@ class StatusCake(object):
         'Virus': (int, (0, 1), None),
         'FindString': (six.string_types, None, None),
         'DoNotFind': (int, (0, 1), None),
-        'TestType': (six.string_types, ("HTTP", "TCP", "PING"), None),
+        'TestType': (six.string_types, ("HTTP", "TCP", "PING", "PUSH"), None),
         'ContactGroup': (six.string_types, None, None),
         'RealBrowser': (int, (0, 1), None),
         'TriggerRate': (int, range(0, 61), None),

--- a/statuscake/api.py
+++ b/statuscake/api.py
@@ -243,6 +243,9 @@ class StatusCake(object):
             raise StatusCakeError("data argument must be a dict")
         if 'TestID' not in data:
             raise StatusCakeFieldMissingError("TestID missing")
+        if 'CheckRate' not in data:
+            # Use default
+            data['CheckRate'] = 300
         # Convert list to CSV string of ints
         if 'ContactGroup' in data:
             if isinstance(data['ContactGroup'], list):


### PR DESCRIPTION
- Fix:`ContactGroup` expects csv string of ints ref #20
- Add support for `PUSH` tests
- Require `CheckRate` when calling `update_test()`. This is a work around for an API bug which causes CheckRate to be reset when `update_test()` called and CheckRate is not included.
- Convert `Paused` bool to int. ie provide support for round-tripping API data.
- Update comment. Default `CheckRate` varies depending on subscription plan.  